### PR TITLE
Null validation in ClickContainerPacket.cs

### DIFF
--- a/Obsidian/Net/Packets/Play/Serverbound/ClickContainerPacket.cs
+++ b/Obsidian/Net/Packets/Play/Serverbound/ClickContainerPacket.cs
@@ -68,8 +68,13 @@ public partial class ClickContainerPacket : IServerboundPacket
         switch (Mode)
         {
             case InventoryOperationMode.MouseClick:
-                await HandleMouseClick(container, server, player, slot);
-                break;
+                {
+                    if (CarriedItem == null)
+                        return;
+                        
+                    await HandleMouseClick(container, server, player, slot);
+                    break;
+                }
 
             case InventoryOperationMode.ShiftMouseClick:
                 {


### PR DESCRIPTION
Clicking on an empty container cell, with nothing in hand, throws a NullReferenceException